### PR TITLE
chore: [KOR-4690] allow postgres version to be set

### DIFF
--- a/postgresql.tf
+++ b/postgresql.tf
@@ -46,7 +46,7 @@ resource "aws_rds_cluster" "postgres" {
   cluster_identifier           = "${var.name}-postgres"
   engine                       = "aurora-postgresql"
   engine_mode                  = "provisioned"
-  engine_version               = "15.5"
+  engine_version               = var.postgres_version
   database_name                = "langfuse"
   master_username              = "langfuse"
   master_password              = random_password.postgres_password.result

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "postgres_max_capacity" {
   default     = 2.0 # Higher default for production readiness
 }
 
+variable "postgres_version" {
+  description = "PostgreSQL engine version to use"
+  type = string
+  default = "15.5"
+}
+
 variable "cache_node_type" {
   description = "ElastiCache node type"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -47,8 +47,8 @@ variable "postgres_max_capacity" {
 
 variable "postgres_version" {
   description = "PostgreSQL engine version to use"
-  type = string
-  default = "15.5"
+  type        = string
+  default     = "15.5"
 }
 
 variable "cache_node_type" {


### PR DESCRIPTION
also have a PR up against the original project

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the AWS RDS cluster configuration to allow the PostgreSQL version to be set via a variable instead of a fixed value.

### Why are these changes being made?

This change increases flexibility by allowing the PostgreSQL version to be configured dynamically, which can facilitate upgrades and environment-specific settings without altering code. This approach enhances maintainability and accommodates different deployment requirements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->