### PR TITLE
feat: [KOR-4681] allow alb scheme and ingress cidrs to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module aims to provide a production-ready, secure, and scalable deployment 
 
 ```hcl
 module "langfuse" {
-  source = "github.com/langfuse/langfuse-terraform-aws?ref=0.2.6"
+  source = "github.com/langfuse/langfuse-terraform-aws?ref=0.3.0"
 
   domain = "langfuse.example.com"
 
@@ -120,6 +120,36 @@ Navigate to your domain, e.g. langfuse.example.com, to access the Langfuse UI.
 
 > :information_source: For more information on Langfuse's architecture, please check [the official documentation](https://langfuse.com/self-hosting#architecture)
 
+## Resource Configuration
+
+This module provides configurable resource allocation for all container workloads to ensure optimal performance in production environments. On AWS EKS Fargate, resource requests and limits are set to the same value for each container.
+The default values are based on the recommendations from the [Langfuse K8s documentation](https://github.com/langfuse/langfuse-k8s) and [Bitnami ClickHouse chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/clickhouse).
+
+### Default Resource Allocations
+
+- **Langfuse containers** (web and worker): 2 CPU, 4 GiB memory
+- **ClickHouse containers**: 2 CPU, 8 GiB memory
+- **ClickHouse Keeper containers**: 1 CPU, 2 GiB memory
+
+These defaults provide a good starting point for production workloads, but you can adjust them based on your specific requirements by setting the corresponding variables in your Terraform configuration.
+
+### Customizing Resources
+
+You can override any of the resource configurations by setting the appropriate variables.
+For example, to increase ClickHouse Keeper resources:
+
+```hcl
+module "langfuse" {
+  source = "github.com/langfuse/langfuse-terraform-aws?ref=0.2.6"
+
+  domain = "langfuse.example.com"
+
+  # Increase ClickHouse Keeper resources
+  clickhouse_keeper_cpu    = "2"
+  clickhouse_keeper_memory = "4Gi"
+}
+```
+
 ## Features
 
 This module creates a complete Langfuse stack with the following components:
@@ -188,6 +218,12 @@ This module creates a complete Langfuse stack with the following components:
 | cache_node_type            | ElastiCache node type                                                                          | string       | "cache.t4g.small"                      |    no    |
 | cache_instance_count       | Number of ElastiCache instances                                                                | number       | 1                                      |    no    |
 | langfuse_helm_chart_version | Version of the Langfuse Helm chart to deploy                                                  | string       | "1.2.15"                                |    no    |
+| langfuse_cpu               | CPU allocation for Langfuse containers                                                        | string       | "2"                                    |    no    |
+| langfuse_memory            | Memory allocation for Langfuse containers                                                     | string       | "4Gi"                                  |    no    |
+| clickhouse_cpu             | CPU allocation for ClickHouse containers                                                      | string       | "2"                                    |    no    |
+| clickhouse_memory          | Memory allocation for ClickHouse containers                                                   | string       | "8Gi"                                  |    no    |
+| clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
+| clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_memory          | Memory allocation for ClickHouse containers                                                   | string       | "8Gi"                                  |    no    |
 | clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
-| alb_scheme                 | ALB scheme                                                                                    | string       |"internet-facing"                      |    no    |
+| alb_scheme                 | ALB scheme                                                                                    | string       | "internet-facing"                      |    no    |
 | ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                                    |    no    |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
 | alb_scheme                 | ALB scheme                                                                                    | string       | "internet-facing"                      |    no    |
-| ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                               |    no    |
+| ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                          |    no    |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
 | alb_scheme                 | ALB scheme                                                                                    | string       | "internet-facing"                      |    no    |
-| ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                                    |    no    |
+| ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                               |    no    |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_memory          | Memory allocation for ClickHouse containers                                                   | string       | "8Gi"                                  |    no    |
 | clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
+| alb_scheme                 | ALB scheme                                                                                    | string       | "internal" or "internet-facing"                      |    no    |
+| ingress_inbound_cidrs       | Allowed CIDR blocks for ingress alb  | ["0.0.0.0/0"]      | list(string) | no
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_memory          | Memory allocation for ClickHouse containers                                                   | string       | "8Gi"                                  |    no    |
 | clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
-| alb_scheme                 | ALB scheme                                                                                    | string       | "internal" or "internet-facing"                      |    no    |
-| ingress_inbound_cidrs       | Allowed CIDR blocks for ingress alb                                                          | list(string) | ["0.0.0.0/0"]                                    |    no    |
+| alb_scheme                 | ALB scheme                                                                                    | string       |"internet-facing"                      |    no    |
+| ingress_inbound_cidrs      | Allowed CIDR blocks for ingress alb                                                           | list(string) | ["0.0.0.0/0"]                                    |    no    |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This module creates a complete Langfuse stack with the following components:
 | clickhouse_keeper_cpu      | CPU allocation for ClickHouse Keeper containers                                               | string       | "1"                                    |    no    |
 | clickhouse_keeper_memory   | Memory allocation for ClickHouse Keeper containers                                            | string       | "2Gi"                                  |    no    |
 | alb_scheme                 | ALB scheme                                                                                    | string       | "internal" or "internet-facing"                      |    no    |
-| ingress_inbound_cidrs       | Allowed CIDR blocks for ingress alb  | ["0.0.0.0/0"]      | list(string) | no
+| ingress_inbound_cidrs       | Allowed CIDR blocks for ingress alb                                                          | list(string) | ["0.0.0.0/0"]                                    |    no    |
 
 ## Outputs
 

--- a/efs.tf
+++ b/efs.tf
@@ -1,7 +1,7 @@
 # EFS File System
 resource "aws_efs_file_system" "langfuse" {
-  creation_token = "${var.name}-efs"
-  encrypted      = true
+  creation_token  = "${var.name}-efs"
+  encrypted       = true
   throughput_mode = "elastic"
 
   tags = {

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -16,6 +16,14 @@ langfuse:
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: ${aws_iam_role.langfuse_irsa.arn}
+  # Resource configuration for production workloads
+  resources:
+    limits:
+      cpu: "${var.langfuse_cpu}"
+      memory: "${var.langfuse_memory}"
+    requests:
+      cpu: "${var.langfuse_cpu}"
+      memory: "${var.langfuse_memory}"
   # The Web container needs slightly increased initial grace period on Fargate
   web:
     livenessProbe:
@@ -35,6 +43,23 @@ clickhouse:
   auth:
     existingSecret: langfuse
     existingSecretKey: clickhouse-password
+  # Resource configuration for ClickHouse containers
+  resources:
+    limits:
+      cpu: "${var.clickhouse_cpu}"
+      memory: "${var.clickhouse_memory}"
+    requests:
+      cpu: "${var.clickhouse_cpu}"
+      memory: "${var.clickhouse_memory}"
+  # Resource configuration for ClickHouse Keeper
+  zookeeper:
+    resources:
+      limits:
+        cpu: "${var.clickhouse_keeper_cpu}"
+        memory: "${var.clickhouse_keeper_memory}"
+      requests:
+        cpu: "${var.clickhouse_keeper_cpu}"
+        memory: "${var.clickhouse_keeper_memory}"
 redis:
   deploy: false
   host: ${aws_elasticache_replication_group.redis.primary_endpoint_address}

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -1,5 +1,5 @@
 locals {
-  langfuse_values = <<EOT
+  langfuse_values   = <<EOT
 global:
   defaultStorageClass: efs
 langfuse:
@@ -55,21 +55,31 @@ s3:
   mediaUpload:
     prefix: "media/"
 EOT
-  ingress_values  = <<EOT
+  ingress_values    = <<EOT
 langfuse:
   ingress:
     enabled: true
     className: alb
     annotations:
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
+      alb.ingress.kubernetes.io/scheme: internal
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/inbound-cidrs: 172.31.0.0/16,172.41.0.0/16
       alb.ingress.kubernetes.io/ssl-redirect: '443'
     hosts:
     - host: ${var.domain}
       paths:
       - path: /
         pathType: Prefix
+  web:
+   resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 1
+        memory: 2Gi
+
 EOT
   encryption_values = var.use_encryption_key == false ? "" : <<EOT
 langfuse:

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -89,8 +89,8 @@ langfuse:
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
       alb.ingress.kubernetes.io/scheme: internal
       alb.ingress.kubernetes.io/target-type: 'ip'
-      alb.ingress.kubernetes.io/inbound-cidrs: 172.31.0.0/16,172.41.0.0/16
       alb.ingress.kubernetes.io/ssl-redirect: '443'
+      alb.ingress.kubernetes.io/inbound-cidrs: 172.31.0.0/16,172.41.0.0/16
     hosts:
     - host: ${var.domain}
       paths:

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -96,15 +96,6 @@ langfuse:
       paths:
       - path: /
         pathType: Prefix
-  web:
-   resources:
-      requests:
-        cpu: 500m
-        memory: 1Gi
-      limits:
-        cpu: 1
-        memory: 2Gi
-
 EOT
   encryption_values = var.use_encryption_key == false ? "" : <<EOT
 langfuse:

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -63,7 +63,7 @@ langfuse:
     annotations:
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
       alb.ingress.kubernetes.io/scheme: internal
-      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/inbound-cidrs: 172.31.0.0/16,172.41.0.0/16
       alb.ingress.kubernetes.io/ssl-redirect: '443'
     hosts:

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -1,4 +1,5 @@
 locals {
+  inbound_cidrs_csv = join(",", var.ingress_inbound_cidrs)
   langfuse_values   = <<EOT
 global:
   defaultStorageClass: efs
@@ -87,10 +88,10 @@ langfuse:
     className: alb
     annotations:
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
-      alb.ingress.kubernetes.io/scheme: internal
+      alb.ingress.kubernetes.io/scheme: ${var.alb_scheme}
       alb.ingress.kubernetes.io/target-type: 'ip'
       alb.ingress.kubernetes.io/ssl-redirect: '443'
-      alb.ingress.kubernetes.io/inbound-cidrs: 172.31.0.0/16,172.41.0.0/16
+      alb.ingress.kubernetes.io/inbound-cidrs: ${local.inbound_cidrs_csv}
     hosts:
     - host: ${var.domain}
       paths:

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,40 @@ variable "langfuse_helm_chart_version" {
   type        = string
   default     = "1.2.15"
 }
+
+# Resource configuration variables
+variable "langfuse_cpu" {
+  description = "CPU allocation for Langfuse containers"
+  type        = string
+  default     = "2"
+}
+
+variable "langfuse_memory" {
+  description = "Memory allocation for Langfuse containers"
+  type        = string
+  default     = "4Gi"
+}
+
+variable "clickhouse_cpu" {
+  description = "CPU allocation for ClickHouse containers"
+  type        = string
+  default     = "2"
+}
+
+variable "clickhouse_memory" {
+  description = "Memory allocation for ClickHouse containers"
+  type        = string
+  default     = "8Gi"
+}
+
+variable "clickhouse_keeper_cpu" {
+  description = "CPU allocation for ClickHouse Keeper containers"
+  type        = string
+  default     = "1"
+}
+
+variable "clickhouse_keeper_memory" {
+  description = "Memory allocation for ClickHouse Keeper containers"
+  type        = string
+  default     = "2Gi"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,3 +127,15 @@ variable "clickhouse_keeper_memory" {
   type        = string
   default     = "2Gi"
 }
+
+variable "alb_scheme" {
+  description = "Scheme for the ALB (internal or internet-facing)"
+  type        = string
+  default     = "internet-facing"
+}
+
+variable "ingress_inbound_cidrs" {
+  description = "List of CIDR blocks allowed to access the ingress"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add parameters to specify ALB scheme and allowed ingress CIDRs within the Langfuse stack configuration.

### Why are these changes being made?

These changes allow more flexible configuration of the ALB scheme (such as internal or internet-facing) and ingress CIDR blocks, providing greater control over network access and improving security by enabling users to define specific access rules tailored to their deployment needs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->