### PR TITLE
fix: [KOR-4991] startupProbe for web container

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -28,6 +28,9 @@ langfuse:
   # The Web container needs slightly increased initial grace period on Fargate
   web:
     replicas: ${var.langfuse_web_replicas}
+    # increased startupProbe for db migration during langfuse version update
+    startupProbe:
+      initialDelaySeconds: 300
     livenessProbe:
       initialDelaySeconds: 60
     readinessProbe:


### PR DESCRIPTION
add startupProbe with long initial delay to allow long running db migrations to complete during langfuse version upgrade

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Increase the `startupProbe.initialDelaySeconds` for the web container in `langfuse.tf` to 300 seconds.

### Why are these changes being made?

The increased delay accommodates database migration during a Langfuse version update, ensuring the web container has ample time to start up without prematurely failing the probe. This change mitigates startup issues in Fargate environments to maintain service continuity during updates.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->